### PR TITLE
fix azure disk mount method : use /dev/disk/azure/scsi1/lun0

### DIFF
--- a/files/mount-data-disk.sh.tpl
+++ b/files/mount-data-disk.sh.tpl
@@ -1,7 +1,7 @@
 if [ ! -d "/data" ]; then
-  yes | mkfs -t ext4 /dev/sdc
+  yes | mkfs -t ext4 /dev/disk/azure/scsi1/lun0
   mkdir -p /data
-  echo "/dev/sdc /data ext4 defaults,nofail,noatime,nodelalloc 0 2" >> /etc/fstab
+  echo "/dev/disk/azure/scsi1/lun0 /data ext4 defaults,nofail,noatime,nodelalloc 0 2" >> /etc/fstab
   mount -a
   ret=$?
   chown -R azureuser:azureuser /data


### PR DESCRIPTION
## issue

I am writing to report an issue with mounting the /data directory on one of our Linux virtual machines in Azure. We have added the following line to the /etc/fstab file to mount the /data directory on the VM: '/dev/sdc /data ext4 defaults,nofail,noatime,nodelalloc 0 2'. However, after the VM starts, the 'df -h' output shows that the /dev/sdc device is missing, and the 'ls -la /data' command shows that the 'lost+found' directory is also missing.

I have compared the output of the 'fdisk -l' command on this VM with that of a normally functioning VM and noticed that the order of device names is not consistent.

In the problematic VM, the /dev/sdc device is listed as 34.4 GB, while on a normally functioning VM, the same device is listed as 214.7 GB. This suggests that the device names /dev/sdb and /dev/sdc may have been swapped on the problematic VM, leading to the incorrect mount point for the /data directory. It's possible that this is causing the missing lost+found directory and the discrepancy between the output of df -h and the entries in /etc/fstab.


auto-mount-data-disk.sh.tpl :
>  yes | mkfs -t ext4 /dev/sdc
>  mkdir -p /data
>  echo '/dev/sdc /data ext4 defaults,nofail,noatime,nodelalloc 0 2' ＞＞ /etc/fstab
>  mount -a

problematic VM:

- Disk /dev/sdb: 214.7 GB (data disk)
- Disk /dev/sda: 107.4 GB
- Disk /dev/sdc: 34.4 GB

Normal vm:

- Disk /dev/sdb: 34.4 GB
- Disk /dev/sda: 107.4 GB
- Disk /dev/sdc: 214.7 GB (data disk)

terraform code of data_disk :

>      attach_setting = {
>        lun = 0
>        caching = 'ReadWrite'        
>      }

## fix

https://learn.microsoft.com/en-us/troubleshoot/azure/virtual-machines/troubleshoot-device-names-problems
https://raw.githubusercontent.com/Azure/WALinuxAgent/master/config/66-azure-storage.rules

> - When data disks are detached and reattached, the disk device names are changed.

## test for `/dev/disk/azure/scsi1/lun$N`

terraform code for multi-data-disks

```
  data_disks = [
    {
      name = "testdisk-data-disk1-${count.index}"
      create_option = "Empty"
      attach_setting = {
        lun = 0
        caching = "ReadWrite"
      }
      storage_account_type = "Standard_LRS"
      disk_size_gb         = 200
    },
    {
      name = "testdisk-data-disk2-${count.index}"
      create_option = "Empty"
      attach_setting = {
        lun = 1
        caching = "ReadWrite"
      }
      storage_account_type = "Standard_LRS"
      disk_size_gb         = 300
    }
  ]
```

confirm

![image](https://user-images.githubusercontent.com/689799/220102607-c4540912-d26b-4403-acd4-344cf1551b31.png)

```
[azureuser@tidb-test-testdisk-0 ~]$ ls -l /dev/disk/azure/scsi*/lun*
lrwxrwxrwx. 1 root root 12 Feb 20 11:46 /dev/disk/azure/scsi1/lun0 -> ../../../sdc
lrwxrwxrwx. 1 root root 12 Feb 20 11:45 /dev/disk/azure/scsi1/lun1 -> ../../../sdd
```

```
[azureuser@tidb-test-testdisk-1 ~]$ df -h | grep /data
/dev/sdd        197G   61M  187G   1% /data
/dev/sdc        296G   65M  281G   1% /data2

# restart server

[azureuser@tidb-test-testdisk-1 ~]$ df -h | grep /data
/dev/sdd        296G   65M  281G   1% /data2 # changed
/dev/sdc        197G   61M  187G   1% /data

# restart server

[azureuser@tidb-test-testdisk-1 ~]$ df -h | grep /data
/dev/sdd        296G   65M  281G   1% /data2
/dev/sdc        197G   61M  187G   1% /data

```